### PR TITLE
Update shebang to use python3 instead of python

### DIFF
--- a/configure.py
+++ b/configure.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 """
 Configuration program for botan


### PR DESCRIPTION
Update shebang to use python3 instead of python, this was causing issues in mac build, you can overcome those by pointing python to python3 but it's not really stardard.