### PR TITLE
PP-518 Android Build

### DIFF
--- a/doc/building.rst
+++ b/doc/building.rst
@@ -236,6 +236,10 @@ configure using the appropriate NDK compiler::
 
   $ export CXX=/opt/android-ndk/toolchains/llvm/prebuilt/linux-x86_64/bin/aarch64-linux-android28-clang++
   $ ./configure.py --os=android --cc=clang --cpu=arm64
+  $ make
+
+If you are building for mobile development consider restricting the build
+to only what you need (see :ref:`minimized_builds`)
 
 Docker
 ^^^^^^^^^^^
@@ -243,7 +247,7 @@ Docker
 To build android version, there is the possibility to use
 the docker way::
 
-  sudo ANDROID_SDK_VER=21 ANDROID_ARCH=arm64 src/scripts/docker-android.sh
+  sudo ANDROID_SDK_VER=29 ANDROID_ARCH=aarch64 src/scripts/docker-android.sh
 
 This will produce the docker-builds/android folder containing
 each architecture compiled.

--- a/src/build-data/os/android.txt
+++ b/src/build-data/os/android.txt
@@ -1,6 +1,9 @@
 
 soname_suffix "so"
 
+soname_pattern_base "lib{libname}.so"
+shared_lib_symlinks no
+
 <target_features>
 posix1
 posix_mlock

--- a/src/scripts/Dockerfile.android
+++ b/src/scripts/Dockerfile.android
@@ -1,8 +1,4 @@
 FROM devnexen/android-ndk:r20 AS android-ndk
-ARG ANDROID_ARCH
-ARG ANDROID_TOOLCHAIN_SUF
-ARG ANDROID_ARCH_SUF
-ARG ANDROID_SDK_VER
 RUN apt-get update && apt-get install -y --no-install-recommends python
 RUN mkdir -p /botan/android
 WORKDIR /botan
@@ -11,6 +7,10 @@ COPY src src
 COPY doc doc
 COPY license.txt license.txt
 COPY news.rst news.rst
+ARG ANDROID_ARCH
+ARG ANDROID_TOOLCHAIN_SUF
+ARG ANDROID_ARCH_SUF
+ARG ANDROID_SDK_VER
 ENV PATH=$PATH:/opt/android-ndk/toolchains/llvm/prebuilt/linux-x86_64/bin/
 RUN ./configure.py --prefix=android/arm --os=android --cpu=${ANDROID_ARCH} --cc=clang --cc-bin=${ANDROID_ARCH}${ANDROID_ARCH_SUF}-linux-android${ANDROID_TOOLCHAIN_SUF}${ANDROID_SDK_VER}-clang++ --ar-command=${ANDROID_ARCH}${ANDROID_ARCH_SUF}-linux-android${ANDROID_TOOLCHAIN_SUF}-ar
 RUN make -j`getconf _NPROCESSORS_ONLN`

--- a/src/scripts/install.py
+++ b/src/scripts/install.py
@@ -199,7 +199,7 @@ def main(args):
             copy_executable(os.path.join(out_dir, soname_patch),
                             prepend_destdir(os.path.join(lib_dir, soname_patch)))
 
-            if target_os != "openbsd":
+            if cfg['symlink_shared_lib']:
                 prev_cwd = os.getcwd()
                 try:
                     os.chdir(prepend_destdir(lib_dir))


### PR DESCRIPTION
This PR adds a script to prebuild Botan for Android.

It also commits the prebuild artifacts to git. They are ~31 MB in size. The releases section would obviously be a better place for this. But short term having them in git makes it easier to pull them in during the Android gradle build.

Related: PP-518, CORE-495.