### PR TITLE
Add sha256sums to release artifacts + include .so

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,7 +21,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - run: |
-          ./configure.py --cc=clang --disable-shared-library --prefix install
+          ./configure.py --cc=clang --prefix install
           make -j8
           make install
       - name: Archive Release
@@ -48,7 +48,7 @@ jobs:
         with:
           arch: amd64
       - run: |
-          python3 configure.py --cc=msvc --disable-shared-library --os=windows --prefix install
+          python3 configure.py --cc=msvc --os=windows --prefix install
           nmake
           nmake check
           nmake install


### PR DESCRIPTION
Add sha256sums to release artifacts. Not security critical, it would be better to sign releases. But nice to have as a quick check of download integrity.

Also some formatting from RedHat's YAML plugin for VS Code.

I haven't tested this, it looks okay, we'll see on the next release.