### PR TITLE
Update to vanilla Botan 3 with own release scripts

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,72 @@
+# This workflow does the following:
+#
+#   1. builds botan on Ubuntu and Windows
+#   2. creates a release, if it doesn't exist
+#   3. uploads the artifacts to that release
+#
+# This is done whenever a new tag is created.
+#
+name: release
+
+on:
+  push:
+    tags:
+      - "*"
+
+jobs:
+  ubuntu-release:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v4
+      # The PREFIX is set to /opt/botan-3, which affects the generated pkgconfig file.
+      # See https://www.pathname.com/fhs/pub/fhs-2.3.html#OPTADDONAPPLICATIONSOFTWAREPACKAGES for
+      # more details about using /opt.
+      - run: |
+          ./configure.py --cc=clang --prefix /opt/botan-3
+          make -j8
+          make install
+      - name: Archive Release
+        uses: thedoctor0/zip-release@0.7.5
+        with:
+          type: "zip"
+          filename: "ubuntu-release-3.zip"
+          directory: /opt
+          path: botan-3
+      - name: Compute checksum
+        run: sha256sum /opt/ubuntu-release-3.zip > ubuntu-release-3.sha256sum
+      - name: Create release
+        uses: ncipollo/release-action@v1
+        with:
+          allowUpdates: true
+          artifacts: "/opt/ubuntu-release-3.zip,ubuntu-release-3.sha256sum"
+          prerelease: true
+
+  windows-release:
+    runs-on: windows-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ilammy/msvc-dev-cmd@v1
+        with:
+          arch: amd64
+      - run: |
+          python3 configure.py --cc=msvc --os=windows --prefix install --build-tool=ninja
+          ninja
+          ninja install
+      - name: Archive Release
+        uses: thedoctor0/zip-release@0.7.5
+        with:
+          type: "zip"
+          filename: "windows-release-3.zip"
+          directory: install
+      - name: Compute checksum
+        run: sha256sum install/windows-release-3.zip > windows-release-3.sha256sum
+      - name: Create release
+        uses: ncipollo/release-action@v1
+        with:
+          allowUpdates: true
+          artifacts: "install/windows-release-3.zip,windows-release-3.sha256sum"
+          prerelease: true

--- a/.gitignore
+++ b/.gitignore
@@ -96,3 +96,6 @@ callgrind.*
 
 # cscope
 cscope.out
+
+iphone-64/
+


### PR DESCRIPTION
https://plancksecurity.atlassian.net/browse/CORE-421

Use Botan 3 with updated CI scripts for our purposes.